### PR TITLE
let light take time to reach the camera

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,6 +38,7 @@
               </div>
               <div id="delay-slider" class="slider-container"></div>
               <div id="ambient" class="toggle-container"></div>
+              <div id="global" class="toggle-container"></div>
               <h2>Settings</h2>
               <div id="output-view" class="toggle-container"></div>
               <div id="wireframe" class="toggle-container"></div>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -72,10 +72,7 @@ function setupUI() {
   renderer.viewParameters.includeAmbient.setupKeyHandler('a', 'View');
 
   kbd.registerKeyboardShortcut('Escape',
-    (e) => {
-      if (e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) {
-        return false;
-      }
+    () => {
       radiosity.stop();
       animationControls.stop();
     },

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -60,6 +60,13 @@ function setupUI() {
   renderer.viewParameters.viewWireframe.setupHtml('#wireframe');
   renderer.viewParameters.viewWireframe.setupKeyHandler('w', 'View');
 
+  renderer.viewParameters.viewGlobalCamera.addExplanation(`
+    For slow-light radiosity, global camera sees light as it reaches surfaces,
+    while local camera needs the light to arrive at camera position.
+    `);
+  renderer.viewParameters.viewGlobalCamera.setupHtml('#global');
+  renderer.viewParameters.viewGlobalCamera.setupKeyHandler('c', 'View');
+
   renderer.viewParameters.includeAmbient.addExplanation('ProgRad can show light that is yet to be distributed.');
   renderer.viewParameters.includeAmbient.setupHtml('#ambient');
   renderer.viewParameters.includeAmbient.setupKeyHandler('a', 'View');

--- a/frontend/radiosity.js
+++ b/frontend/radiosity.js
@@ -84,7 +84,12 @@ function show(time) {
   const alg = algorithms.value.instance;
   const oldMaxTime = alg.maxTime;
 
-  const changedColors = alg.show(time, renderer.getCameraPosition());
+  const camera =
+    renderer.viewParameters.viewGlobalCamera.value
+      ? null
+      : renderer.getCameraPosition();
+
+  const changedColors = alg.show(time, camera);
 
   if (changedColors) {
     renderer.updateColors();

--- a/frontend/radiosity.js
+++ b/frontend/radiosity.js
@@ -84,7 +84,7 @@ function show(time) {
   const alg = algorithms.value.instance;
   const oldMaxTime = alg.maxTime;
 
-  const changedColors = alg.show(time);
+  const changedColors = alg.show(time, renderer.getCameraPosition());
 
   if (changedColors) {
     renderer.updateColors();

--- a/frontend/renderer.js
+++ b/frontend/renderer.js
@@ -8,7 +8,12 @@ import * as axes from './tools/axes.js';
 import * as components from './tools/basic-components.js';
 
 export const viewParameters = {
-  viewOutput: new components.Toggle('view radiosity output', false), // the current view is either vertex (radiosity) or shaded
+  // the current view is either vertex (radiosity) or shaded
+  viewOutput: new components.Toggle('view radiosity output', false),
+
+  // global camera sees light as it reaches surfaces, local camera waits for the light to reach the camera
+  viewGlobalCamera: new components.Toggle('global camera', true),
+
   viewWireframe: new components.Toggle('wireframe view', false),
   includeAmbient: new components.Toggle('show ambient light', false),
   gamma: new components.Range('gamma', 1, 100, 22), // scaled by 10, so 0.1-10, default 2.2

--- a/frontend/renderer.js
+++ b/frontend/renderer.js
@@ -213,3 +213,7 @@ function animate() {
   axes.update(camera, controls.target);
   axes.render();
 }
+
+export function getCameraPosition() {
+  return camera.position;
+}

--- a/radiosity/point3.js
+++ b/radiosity/point3.js
@@ -14,13 +14,14 @@ export default class Point3 {
   }
 
   equals(p) {
-    return this.x === p.x && this.y === p.y && this.z === p.z;
+    return p && this.x === p.x && this.y === p.y && this.z === p.z;
   }
 
   setTo(p) {
     this.x = p.x;
     this.y = p.y;
     this.z = p.z;
+    return this;
   }
 
   addVector(v) {

--- a/radiosity/point3.js
+++ b/radiosity/point3.js
@@ -13,6 +13,16 @@ export default class Point3 {
     }
   }
 
+  equals(p) {
+    return this.x === p.x && this.y === p.y && this.z === p.z;
+  }
+
+  setTo(p) {
+    this.x = p.x;
+    this.y = p.y;
+    this.z = p.z;
+  }
+
   addVector(v) {
     if (!(v instanceof Vector3)) throw new TypeError('point can only add vectors');
 

--- a/radiosity/slowrad.js
+++ b/radiosity/slowrad.js
@@ -9,7 +9,7 @@ export default class SlowRad {
     this.env = null;                           // Environment
 
     this.ffd = new HemiCube();                 // Form factor determination
-    this.lastCameraPosition = new Point3();
+    this.tmpCamPos = new Point3();             // Object to hold last camera position
   }
 
   open(env, speedOfLight) {
@@ -35,9 +35,11 @@ export default class SlowRad {
   }
 
   show(time, camPos) {
-    const cameraMoved = camPos && !this.lastCameraPosition.equals(camPos);
+    const cameraSwitched = (this.lastCameraPosition == null) !== (camPos == null);
+    const cameraMoved = this.lastCameraPosition && !this.lastCameraPosition.equals(camPos);
+    this.lastCameraPosition = camPos && this.tmpCamPos.setTo(camPos);
 
-    if (this.lastShownTime !== time || cameraMoved || this.needsDisplayUpdate) {
+    if (this.lastShownTime !== time || cameraSwitched || cameraMoved || this.needsDisplayUpdate) {
       this.lastShownTime = time;
       this.needsDisplayUpdate = false;
 

--- a/radiosity/spectra.js
+++ b/radiosity/spectra.js
@@ -16,12 +16,19 @@ export default class Spectra {
 
   reset() {
     this.r = this.g = this.b = 0;
+    return this;
   }
 
   setTo(s) {
+    if (!s) {
+      this.reset();
+      return this;
+    }
+
     this.r = s.r;
     this.g = s.g;
     this.b = s.b;
+    return this;
   }
 
   add(s) {


### PR DESCRIPTION
This code shows what it looks like when we only show light that has had a chance to reach the camera. In effect, the camera sees each surface as it was way back when the light left it that is now reaching the camera – we see a fresher view of closer surfaces and an older view of surfaces that are far away.

If we stop the flow of light, the movement of camera therefore makes the light move too: as we move closer to a surface, it's as if we were moving forward in time; as we move further away from a surface, it's as if we were moving backwards in time.

If the camera is far from a light source, it takes quite some time before any light gets to it.

This needs some more work:

- [x] add a toggle for triggering this behaviour